### PR TITLE
[Feat/HM-81]: 타임피커 컴포넌트 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'import/no-extraneous-dependencies': 'off',
+    'react/no-array-index-key': 'off',
     'react/function-component-definition': [
       'error',
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "eslint-import-resolver-typescript": "^3.6.1",
         "express": "^4.19.2",
+        "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-calendar": "^5.0.0",
@@ -28,6 +29,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/lodash": "^4.17.7",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
@@ -3221,6 +3223,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "peer": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -7435,8 +7443,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "eslint-import-resolver-typescript": "^3.6.1",
     "express": "^4.19.2",
+    "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/lodash": "^4.17.7",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.13.1",

--- a/src/components/bottomsheet/BottomSheetHeader.tsx
+++ b/src/components/bottomsheet/BottomSheetHeader.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import CloseIcon from 'public/assets/icons/common/close.svg';
+
+interface Props {
+  title: string;
+  onClick: () => void;
+}
+
+function BottomSheetHeader({ title, onClick }: Props) {
+  return (
+    <Header>
+      <Title>{title}</Title>
+      <button type="button" onClick={onClick}>
+        <img src={CloseIcon} alt="close" />
+      </button>
+    </Header>
+  );
+}
+
+export const Header = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  img {
+    cursor: pointer;
+  }
+`;
+
+export const Title = styled.div`
+  ${({ theme }) => theme.typo.body.semi_bold[22]}
+  color: ${({ theme }) => theme.color.secondary.solid.bk[900]};
+`;
+
+export default BottomSheetHeader;

--- a/src/components/bottomsheet/EndDate.tsx
+++ b/src/components/bottomsheet/EndDate.tsx
@@ -1,6 +1,5 @@
 import { Badge } from '@/styles/components/badge';
 import styled from 'styled-components';
-import CloseIcon from 'public/assets/icons/common/close.svg';
 import { useState } from 'react';
 import moment from 'moment';
 import { useEndDateModal } from '@/store/useModalStore';
@@ -8,13 +7,12 @@ import { useEndDateStore, useStartDateStore } from '@/store/useDateStore';
 import calculateDate from '@/utils/calculateDate';
 import {
   BottomSheetContainer,
-  BottomSheetHeader,
-  BottomSheetTitle,
   BottomSheetInfoWrapper,
   BottomSheetInfo,
 } from '@/styles/components/bottomsheet/bottomsheet';
 import Button from '../common/Button';
 import Calendar from './Calendar';
+import BottomSheetHeader from './BottomSheetHeader';
 
 function EndDate() {
   const [endDate, setEndDate] = useState(
@@ -44,12 +42,7 @@ function EndDate() {
 
   return (
     <BottomSheetContainer>
-      <BottomSheetHeader>
-        <BottomSheetTitle>종료일 선택</BottomSheetTitle>
-        <button type="button" onClick={closeEndDate}>
-          <img src={CloseIcon} alt="close" />
-        </button>
-      </BottomSheetHeader>
+      <BottomSheetHeader title="종료일 선택" onClick={closeEndDate} />
       <BottomSheetInfoWrapper>
         <Badge>종료일</Badge>
         <BottomSheetInfo>{endDate}</BottomSheetInfo>

--- a/src/components/bottomsheet/StartDate.tsx
+++ b/src/components/bottomsheet/StartDate.tsx
@@ -1,24 +1,23 @@
 import { Badge } from '@/styles/components/badge';
 import styled from 'styled-components';
-import CloseIcon from 'public/assets/icons/common/close.svg';
 import { useState } from 'react';
 import moment from 'moment';
 import { useStartDateModal } from '@/store/useModalStore';
 import { useStartDateStore } from '@/store/useDateStore';
 import {
   BottomSheetContainer,
-  BottomSheetHeader,
-  BottomSheetTitle,
   BottomSheetInfoWrapper,
   BottomSheetInfo,
 } from '@/styles/components/bottomsheet/bottomsheet';
 import Button from '../common/Button';
 import Calendar from './Calendar';
+import BottomSheetHeader from './BottomSheetHeader';
 
 function StartDate() {
   const [startDate, setStartDate] = useState(
     moment(new Date()).format('YYYY-MM-DD')
   );
+
   const closeStartDate = useStartDateModal((state) => state.close);
   const updateStartDate = useStartDateStore((state) => state.updateDate);
 
@@ -29,12 +28,7 @@ function StartDate() {
 
   return (
     <BottomSheetContainer>
-      <BottomSheetHeader>
-        <BottomSheetTitle>시작일 선택</BottomSheetTitle>
-        <button type="button" onClick={closeStartDate}>
-          <img src={CloseIcon} alt="close" />
-        </button>
-      </BottomSheetHeader>
+      <BottomSheetHeader title="시작일 선택" onClick={closeStartDate} />
       <BottomSheetInfoWrapper>
         <Badge>시작일</Badge>
         <BottomSheetInfo>{startDate}</BottomSheetInfo>

--- a/src/components/bottomsheet/TimePicker.tsx
+++ b/src/components/bottomsheet/TimePicker.tsx
@@ -4,6 +4,7 @@ import { useTimeModal } from '@/store/useModalStore';
 import { useEffect, useRef, useState } from 'react';
 import { useEndTimeStore, useStartTimeStore } from '@/store/useTimeStore';
 import { SetTime } from '@/types/SetTime';
+import throttle from 'lodash/throttle';
 import BottomSheetHeader from './BottomSheetHeader';
 import Button from '../common/Button';
 
@@ -34,14 +35,17 @@ function TimePicker({ type }: Props) {
     const hourList = hourListRef.current;
 
     if (hourList) {
-      const handleScroll = (event: Event) => {
+      const handleScroll = throttle((event: Event) => {
         const target = event.target as HTMLUListElement;
         const maxScrollHeight = target.scrollHeight - target.clientHeight;
 
-        if (hourList.scrollTop === maxScrollHeight) {
+        if (
+          Math.floor(target.scrollTop) === maxScrollHeight ||
+          Math.floor(target.scrollTop) === maxScrollHeight - 1
+        ) {
           setHours((prev) => [...prev, ...hours]);
         }
-      };
+      }, 1000);
 
       hourList.addEventListener('scroll', handleScroll);
 

--- a/src/components/bottomsheet/TimePicker.tsx
+++ b/src/components/bottomsheet/TimePicker.tsx
@@ -34,14 +34,18 @@ function TimePicker({ type }: Props) {
     const hourList = hourListRef.current;
 
     if (hourList) {
-      hourList.addEventListener('scroll', (event) => {
+      const handleScroll = (event: Event) => {
         const target = event.target as HTMLUListElement;
         const maxScrollHeight = target.scrollHeight - target.clientHeight;
 
         if (hourList.scrollTop === maxScrollHeight) {
           setHours((prev) => [...prev, ...hours]);
         }
-      });
+      };
+
+      hourList.addEventListener('scroll', handleScroll);
+
+      return () => hourList.removeEventListener('scroll', handleScroll);
     }
     return undefined;
   }, [hours]);

--- a/src/components/bottomsheet/TimePicker.tsx
+++ b/src/components/bottomsheet/TimePicker.tsx
@@ -135,10 +135,10 @@ const SelectItem = styled.li<{ $isSelected: boolean }>`
 
     ${({ theme }) => theme.typo.body.regular[22]}
 
-    ${({ theme, $isSelected }) => {
-      if ($isSelected) return `color: ${theme.color.point.purple}`;
-      return `color: ${theme.color.secondary.solid.bk[400]}`;
-    }}
+    color: ${({ theme, $isSelected }) =>
+      $isSelected
+        ? theme.color.point.purple
+        : theme.color.secondary.solid.bk[400]}
   }
 `;
 

--- a/src/components/bottomsheet/TimePicker.tsx
+++ b/src/components/bottomsheet/TimePicker.tsx
@@ -1,0 +1,142 @@
+import { BottomSheetContainer } from '@/styles/components/bottomsheet/bottomsheet';
+import styled from 'styled-components';
+import { useTimeModal } from '@/store/useModalStore';
+import { useEffect, useRef, useState } from 'react';
+import { useEndTimeStore, useStartTimeStore } from '@/store/useTimeStore';
+import { SetTime } from '@/types/SetTime';
+import BottomSheetHeader from './BottomSheetHeader';
+import Button from '../common/Button';
+
+interface Props {
+  type: SetTime;
+}
+
+function TimePicker({ type }: Props) {
+  const [selectedHour, setSelectedHour] = useState('');
+  const [selectedMin, setSelectedMin] = useState('');
+  const [hours, setHours] = useState<string[]>(
+    Array.from({ length: 24 }, (_, index) => String(index))
+  );
+
+  const hourListRef = useRef<HTMLUListElement>(null);
+  const updateStartTime = useStartTimeStore((state) => state.updateTime);
+  const updateEndTime = useEndTimeStore((state) => state.updateTime);
+  const closeTime = useTimeModal((state) => state.close);
+
+  const handleClickButton = () => {
+    const updatedTime = `${selectedHour}:${selectedMin}`;
+    if (type === 'start') updateStartTime(updatedTime);
+    if (type === 'end') updateEndTime(updatedTime);
+    closeTime();
+  };
+
+  useEffect(() => {
+    const hourList = hourListRef.current;
+
+    if (hourList) {
+      hourList.addEventListener('scroll', (event) => {
+        const target = event.target as HTMLUListElement;
+        const maxScrollHeight = target.scrollHeight - target.clientHeight;
+
+        if (hourList.scrollTop === maxScrollHeight) {
+          setHours((prev) => [...prev, ...hours]);
+        }
+      });
+    }
+    return undefined;
+  }, [hours]);
+
+  return (
+    <Container>
+      <BottomSheetHeader title="시간 선택" onClick={closeTime} />
+      <TimePickerContainer>
+        <SelectHour ref={hourListRef}>
+          {hours.map((item, index) => (
+            <SelectItem key={item + index} $isSelected={item === selectedHour}>
+              <button type="button" onClick={() => setSelectedHour(item)}>
+                {item}
+              </button>
+            </SelectItem>
+          ))}
+        </SelectHour>
+        <SelectMinute>
+          {['00', '30'].map((item) => (
+            <SelectItem $isSelected={item === selectedMin}>
+              <button type="button" onClick={() => setSelectedMin(item)}>
+                {item}
+              </button>
+            </SelectItem>
+          ))}
+        </SelectMinute>
+      </TimePickerContainer>
+      <ButtonContainer>
+        <Button
+          $style="solid"
+          disabled={selectedHour === '' || selectedMin === ''}
+          onClick={handleClickButton}
+        >
+          완료
+        </Button>
+      </ButtonContainer>
+    </Container>
+  );
+}
+
+const Container = styled(BottomSheetContainer)`
+  height: 50%;
+`;
+
+const ButtonContainer = styled.div`
+  position: absolute;
+  bottom: 16px;
+  width: 100%;
+  padding: 0 24px;
+`;
+
+const TimePickerContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  width: 160px;
+  height: 180px;
+`;
+
+const SelectHour = styled.ul`
+  height: 100%;
+  overflow: scroll;
+`;
+
+const SelectItem = styled.li<{ $isSelected: boolean }>`
+  padding: 8px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 6px;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.secondary.solid.bk[50]};
+  }
+
+  button {
+    width: 100%;
+    height: 100%;
+
+    ${({ theme }) => theme.typo.body.regular[22]}
+
+    ${({ theme, $isSelected }) => {
+      if ($isSelected) return `color: ${theme.color.point.purple}`;
+      return `color: ${theme.color.secondary.solid.bk[400]}`;
+    }}
+  }
+`;
+
+const SelectMinute = styled.ul`
+  color: ${({ theme }) => theme.color.secondary.solid.bk[400]};
+  ${({ theme }) => theme.typo.body.regular[22]}
+`;
+
+export default TimePicker;

--- a/src/components/bottomsheet/TimePicker.tsx
+++ b/src/components/bottomsheet/TimePicker.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 function TimePicker({ type }: Props) {
-  const [selectedHour, setSelectedHour] = useState('');
-  const [selectedMin, setSelectedMin] = useState('');
+  const [selectedHour, setSelectedHour] = useState<string>();
+  const [selectedMin, setSelectedMin] = useState<string>();
   const [hours, setHours] = useState<string[]>(
     Array.from({ length: 24 }, (_, index) => String(index))
   );
@@ -80,7 +80,7 @@ function TimePicker({ type }: Props) {
       <ButtonContainer>
         <Button
           $style="solid"
-          disabled={selectedHour === '' || selectedMin === ''}
+          disabled={!selectedHour || !selectedMin}
           onClick={handleClickButton}
         >
           완료

--- a/src/components/meeting/result/AttendStatusHeader.tsx
+++ b/src/components/meeting/result/AttendStatusHeader.tsx
@@ -1,8 +1,5 @@
+import BottomSheetHeader from '@/components/bottomsheet/BottomSheetHeader';
 import Button from '@/components/common/Button';
-import {
-  BottomSheetHeader,
-  BottomSheetTitle,
-} from '@/styles/components/bottomsheet/bottomsheet';
 import { useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 
@@ -42,10 +39,10 @@ function AttendStatusHeader({
       )}
       {isBottomSheetOpen && (
         <BottomSheetContainer>
-          <BottomSheetHeader>
-            <BottomSheetTitle>현재 참여 인원</BottomSheetTitle>
-            <CloseButton onClick={toggleBottomSheet}>X</CloseButton>
-          </BottomSheetHeader>
+          <BottomSheetHeader
+            title="현재 참여 인원"
+            onClick={toggleBottomSheet}
+          />
           <ParticipantCountContainer>
             <ParticipantState>
               총 참여 인원 :
@@ -112,14 +109,6 @@ const AttendParticipantCount = styled.button`
   cursor: pointer;
 `;
 
-const CloseButton = styled.button`
-  font-size: 16px;
-  font-weight: bold;
-  color: #33c894;
-  background: none;
-  border: none;
-  cursor: pointer;
-`;
 const ParticipantCountContainer = styled.div`
   display: flex;
   width: 100%;

--- a/src/components/room/SelectTime.tsx
+++ b/src/components/room/SelectTime.tsx
@@ -1,5 +1,6 @@
 import ICONS from '@/constants/icons';
 import { SUB_TITLE } from '@/constants/title';
+import { useEndTimeStore, useStartTimeStore } from '@/store/useTimeStore';
 import { Badge } from '@/styles/components/badge';
 import {
   SelectContainer,
@@ -7,23 +8,31 @@ import {
   SelectableItem,
 } from '@/styles/components/meeting/select';
 import { SubTitle } from '@/styles/components/text';
+import { SetTime } from '@/types/SetTime';
 import styled from 'styled-components';
 
-function SelectTime() {
+interface Props {
+  onClick: (value: SetTime) => void;
+}
+
+function SelectTime({ onClick }: Props) {
+  const startTime = useStartTimeStore((state) => state.time);
+  const endTime = useEndTimeStore((state) => state.time);
+
   return (
     <SelectContainer>
       <SubTitle>{SUB_TITLE.time}</SubTitle>
       <SelectWrapper $horizontal>
-        <SelectableItem>
+        <SelectableItem onClick={() => onClick('start')}>
           <TimeWrapper>
-            <Time>0:00</Time>
+            <Time>{startTime}</Time>
             <Badge>이후</Badge>
           </TimeWrapper>
           <img src={ICONS.common.right} alt="right" />
         </SelectableItem>
-        <SelectableItem>
+        <SelectableItem onClick={() => onClick('end')}>
           <TimeWrapper>
-            <Time>0:00</Time>
+            <Time>{endTime}</Time>
             <Badge>이전</Badge>
           </TimeWrapper>
           <img src={ICONS.common.right} alt="right" />

--- a/src/pages/NewMeetingPage.tsx
+++ b/src/pages/NewMeetingPage.tsx
@@ -1,5 +1,6 @@
 import EndDate from '@/components/bottomsheet/EndDate';
 import StartDate from '@/components/bottomsheet/StartDate';
+import TimePicker from '@/components/bottomsheet/TimePicker';
 import Button from '@/components/common/Button';
 import Header from '@/components/common/Header';
 import Modal from '@/components/common/Modal';
@@ -9,20 +10,32 @@ import SelectTime from '@/components/room/SelectTime';
 import HEAD_TITLE from '@/constants/header';
 import INPUT from '@/constants/input';
 import { TITLE } from '@/constants/title';
-import { useEndDateModal, useStartDateModal } from '@/store/useModalStore';
+import {
+  useEndDateModal,
+  useStartDateModal,
+  useTimeModal,
+} from '@/store/useModalStore';
 import {
   ContentContainer,
   FlexColContainer,
 } from '@/styles/components/container';
 import { PageTitle } from '@/styles/components/text';
+import { SetTime } from '@/types/SetTime';
+import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
 function NewMeetingPage() {
+  const [timeType, setTimeType] = useState<SetTime>('start');
   // TODO 소셜 로그인 유무에 따른 PageTitle 변경 및 버튼 변경
   const { isOpen: isStartDateOpen, close: closeStartDate } =
     useStartDateModal();
   const { isOpen: isEndDateOpen, close: closeEndDate } = useEndDateModal();
+  const {
+    isOpen: isTimeOpen,
+    open: openTime,
+    close: closeTime,
+  } = useTimeModal();
 
   const methods = useForm({
     mode: 'onChange',
@@ -34,6 +47,11 @@ function NewMeetingPage() {
     register,
     formState: { isValid },
   } = methods;
+
+  const handleSetType = (type: SetTime) => {
+    setTimeType(type);
+    openTime();
+  };
 
   return (
     <FlexColContainer>
@@ -51,7 +69,7 @@ function NewMeetingPage() {
           />
         </FormProvider>
         <SelectDate />
-        <SelectTime />
+        <SelectTime onClick={handleSetType} />
       </ContentContainer>
       <ButtonContainer>
         {isValid ? (
@@ -68,6 +86,11 @@ function NewMeetingPage() {
       {isEndDateOpen && (
         <Modal onClose={closeEndDate}>
           <EndDate />
+        </Modal>
+      )}
+      {isTimeOpen && (
+        <Modal onClose={closeTime}>
+          <TimePicker type={timeType} />
         </Modal>
       )}
     </FlexColContainer>

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -15,5 +15,6 @@ const createModalStore = (initialState: boolean) =>
 
 const useStartDateModal = createModalStore(false);
 const useEndDateModal = createModalStore(false);
+const useTimeModal = createModalStore(false);
 
-export { useStartDateModal, useEndDateModal };
+export { useStartDateModal, useEndDateModal, useTimeModal };

--- a/src/store/useTimeStore.ts
+++ b/src/store/useTimeStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface State {
+  time: string;
+  updateTime: (updateTime: string) => void;
+}
+
+const createTimeStore = () =>
+  create<State>((set) => ({
+    time: '0:00',
+    updateTime: (updatedTime) => set(() => ({ time: updatedTime })),
+  }));
+
+const useStartTimeStore = createTimeStore();
+const useEndTimeStore = createTimeStore();
+
+export { useStartTimeStore, useEndTimeStore };

--- a/src/styles/components/bottomsheet/bottomsheet.ts
+++ b/src/styles/components/bottomsheet/bottomsheet.ts
@@ -26,23 +26,6 @@ export const BottomSheetContainer = styled.div`
   animation: ${slideIn} 240ms cubic-bezier(0.5, 0.1, 0.34, 1);
 `;
 
-export const BottomSheetHeader = styled.div`
-  width: 100%;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  img {
-    cursor: pointer;
-  }
-`;
-
-export const BottomSheetTitle = styled.div`
-  ${({ theme }) => theme.typo.body.semi_bold[22]}
-  color: ${({ theme }) => theme.color.secondary.solid.bk[900]};
-`;
-
 export const BottomSheetInfoWrapper = styled.div`
   width: 100%;
 

--- a/src/types/SetTime.ts
+++ b/src/types/SetTime.ts
@@ -1,0 +1,1 @@
+export type SetTime = 'start' | 'end';


### PR DESCRIPTION
## 📍 작업 내용

- [x] 타임피커 컴포넌트 구현
- [x] 선택된 시작, 종료 시간으로 일정 변경

타임 피커 컴포넌트를 구현 했습니다.
다른 라이브러리나 기본 인풋을 사용해 구현해 볼까 하다가, 그렇게 될경우 디자인적으로 많은 수정이 이뤄질것 같아 우선 디자인과 최대한 !! 비슷하게 구현했습니다.
이점은 디자이너님께 다시한번 컨펌 받아보도록 하겠습니다.
<br/>

## 📍 구현 결과 (선택)

<img width="450" alt="스크린샷 2024-08-11 오후 9 08 13" src="https://github.com/user-attachments/assets/b83e121b-1771-4912-b731-b8dbe386a85d">
**_[ 시간선택 컴포넌트 ]_**

<img width="449" alt="스크린샷 2024-08-11 오후 9 08 45" src="https://github.com/user-attachments/assets/9163a605-85bb-4a55-a4cc-2c75f98912c4">
**_[ 선택된 시간으로 변경 ]_**

<br/>

## 📍 기타 사항

추가적으로 최대한의 디자인을 맞추기 위해서 타임 피커 컴포넌트 내부 시간 선택 스크롤 화면을 0~24가 계속해서 반복되게 구현 했습니다.
개발 입장에서 생각했을때는 불필요한 렌더링이라고 생각이 되지만 디자인 관점에서는 필요할 수도 있을것 같아 우선 컨펌을 먼저 받고 불필요할 경우 다시 삭제하도록 하겠습니다.

<br/>
