### PR TITLE
[Feat/HM-126] 비회원 일정만들기 api 구현 및 연동

### DIFF
--- a/src/apis/meeting.api.ts
+++ b/src/apis/meeting.api.ts
@@ -1,0 +1,10 @@
+import { NonMemberMeetingReq } from '@/models/meeting.model';
+import { axiosInstance } from './instance';
+
+const postNonMemberMeeting = async (req: NonMemberMeetingReq) => {
+  const result = await axiosInstance.post('/guest-schedule', req);
+
+  return result;
+};
+
+export default postNonMemberMeeting;

--- a/src/components/login/DefaultLogin.tsx
+++ b/src/components/login/DefaultLogin.tsx
@@ -26,7 +26,11 @@ function DefaultLogin() {
           <SocialLoginButtons />
         </div>
         <Divider />
-        <Button $style="outlined" $theme="primary-green">
+        <Button
+          $style="outlined"
+          $theme="primary-green"
+          onClick={() => navigate(PATH.non_member_meeting)}
+        >
           비회원으로 일정 만들기
         </Button>
         <LoginGuide />

--- a/src/components/newmeeting/ConfirmMeeting.tsx
+++ b/src/components/newmeeting/ConfirmMeeting.tsx
@@ -10,6 +10,9 @@ import styled, { useTheme } from 'styled-components';
 import { NextIcon } from 'public/assets/icons';
 import { Content, MeetingData } from '@/types/meeting';
 import { useQuitMakeMeetingModal } from '@/store/useModalStore';
+
+import useNonMemberMeeting from '@/hooks/useNonMemberMeeting';
+import useConvertTime from '@/hooks/useConvertTime';
 import ProgressBar from './ProgressBar';
 import Button from '../common/Button';
 
@@ -21,6 +24,8 @@ interface Props {
 function ConfirmMeeting({ meetingData, setContent }: Props) {
   const theme = useTheme();
   const openQuit = useQuitMakeMeetingModal((state) => state.open);
+  const { handleMakeNonMemberMeeting } = useNonMemberMeeting();
+  const { convertTimeToPm } = useConvertTime();
 
   const {
     name: { value },
@@ -30,6 +35,17 @@ function ConfirmMeeting({ meetingData, setContent }: Props) {
 
   const handleClickPrev = () => {
     setContent('make');
+  };
+
+  const handleClickMakeMeeting = () => {
+    const meetingDataReq = {
+      ...meetingData,
+      time: {
+        startTime: convertTimeToPm(startTime),
+        endTime: convertTimeToPm(endTime),
+      },
+    };
+    handleMakeNonMemberMeeting(meetingDataReq);
   };
 
   return (
@@ -71,7 +87,7 @@ function ConfirmMeeting({ meetingData, setContent }: Props) {
           <Button
             $style="solid"
             $theme="primary-purple"
-            onClick={() => setContent('login')}
+            onClick={handleClickMakeMeeting}
           >
             일정 생성
           </Button>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_TIMEOUT = 30000;
-export const BASE_URL = 'http://api.howmeet.shop:8080';
+// export const BASE_URL = 'http://api.howmeet.shop:8080';
+export const BASE_URL =
+  'http://ec2-3-37-227-170.ap-northeast-2.compute.amazonaws.com:8080';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,4 +3,5 @@ export const PATH = {
   home: '/home',
   login: '/login',
   new_meeting: '/new-meeting',
+  non_member_meeting: '/new-meeting/non-member',
 } as const;

--- a/src/hooks/useConvertTime.ts
+++ b/src/hooks/useConvertTime.ts
@@ -1,0 +1,14 @@
+const useConvertTime = () => {
+  const convertTimeToPm = (time: string) => {
+    let convertedTime = '';
+    const [hour, minute] = time.split(' ')[1].split(':');
+    if (time.includes('오후')) convertedTime = String(Number(hour) + 12);
+    else convertedTime = hour.length === 1 ? `0${hour}` : hour;
+
+    return `${convertedTime}:${minute}:00`;
+  };
+
+  return { convertTimeToPm };
+};
+
+export default useConvertTime;

--- a/src/hooks/useNonMemberMeeting.ts
+++ b/src/hooks/useNonMemberMeeting.ts
@@ -1,0 +1,22 @@
+import postNonMemberMeeting from '@/apis/meeting.api';
+import { NonMemberMeetingReq } from '@/models/meeting.model';
+import useStepStore from '@/store/meeting/useStepStore';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+const useNonMemberMeeting = () => {
+  const setStep = useStepStore((state) => state.setStep);
+
+  const { mutate: handleMakeNonMemberMeeting } = useMutation({
+    mutationFn: (meetingData: NonMemberMeetingReq) =>
+      postNonMemberMeeting(meetingData),
+    onSuccess: () => {
+      setStep('login');
+    },
+    onError: () => toast.error('잠시후 다시 시도해 주세요.'),
+  });
+
+  return { handleMakeNonMemberMeeting };
+};
+
+export default useNonMemberMeeting;

--- a/src/models/meeting.model.ts
+++ b/src/models/meeting.model.ts
@@ -1,0 +1,10 @@
+export interface NonMemberMeetingReq {
+  dates: string[];
+  time: {
+    startTime: string;
+    endTime: string;
+  };
+  name: {
+    value: string;
+  };
+}


### PR DESCRIPTION
## 📍 작업 내용

비회원 일정 만들기 api를 구현하고 연동 했습니다.

<br/>

## 📍 구현 결과 (선택)


<br/>

## 📍 기타 사항

비회원 일정만들기 (로그인 화면) -> 일정 제목 및 일정 입력 -> 일정 확인 및 일정 생성 (이 과정에서 일정은 생성 이상 없음) -> 비회원 로그인 (여기서 400 badrequest 발생)

<br/>
